### PR TITLE
feat: serve openapi schemas from duty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/flanksource/canary-checker/sdk v0.0.0-20221002171205-15e7cea06125
 	github.com/flanksource/commons v1.6.2
-	github.com/flanksource/duty v1.0.7
+	github.com/flanksource/duty v1.0.8
 	github.com/flanksource/kommons v0.31.1
 	github.com/google/cel-go v0.13.0
 	github.com/google/uuid v1.3.0
@@ -144,7 +144,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/flanksource/canary-checker/sdk v0.0.0-20221002171205-15e7cea06125 h1:
 github.com/flanksource/canary-checker/sdk v0.0.0-20221002171205-15e7cea06125/go.mod h1:JwV0Y7FcdwcgmooZRcF4OV4w+H7Td5auyFHXZla/wjU=
 github.com/flanksource/commons v1.6.2 h1:1VRCNy2Wk7v+uCXyJbsOql9XA6m7oCRd8i6Cx06/3AQ=
 github.com/flanksource/commons v1.6.2/go.mod h1:zOpjd+7WeF691Gsx30+v8X+05BXeBmA4uUK+7CSwNo4=
-github.com/flanksource/duty v1.0.7 h1:h1Y/BH+NnwcMqOLOdoG8Sp4jJVC6viw34cmZpiXMe+E=
-github.com/flanksource/duty v1.0.7/go.mod h1:BWuCnsEp66gX+atH0x1JzVt5KpvfnbCZ6RlOUOsctoI=
+github.com/flanksource/duty v1.0.8 h1:adu+jLD1hROe4lZBpPSyZsPhSUnkk9TmAUqmKbl5cqM=
+github.com/flanksource/duty v1.0.8/go.mod h1:BWuCnsEp66gX+atH0x1JzVt5KpvfnbCZ6RlOUOsctoI=
 github.com/flanksource/gomplate/v3 v3.20.1 h1:aFVvR7gw534ReoEXVUtZm+lWlVq3RMRqF3GhRN3okgM=
 github.com/flanksource/gomplate/v3 v3.20.1/go.mod h1:LPpzujBIg9HBXRUngDKK/zNmEjHpEUieKa/2oRjkCzI=
 github.com/flanksource/kommons v0.31.1 h1:WZjrIYbSAR7xzIvP2uSRQcn5wPi4W9gAasuOM5CD854=

--- a/utils/http.go
+++ b/utils/http.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+func HTTPFileserver(embeddedFS embed.FS) (http.Handler, error) {
+	fsys, err := fs.Sub(embeddedFS, ".")
+	if err != nil {
+		return nil, err
+	}
+	return http.FileServer(http.FS(fsys)), nil
+}


### PR DESCRIPTION
Bump duty version in `go.mod` once https://github.com/flanksource/duty/pull/13 is merged.