### PR TITLE
fix: support done expression for checks

### DIFF
--- a/api/check.go
+++ b/api/check.go
@@ -10,6 +10,8 @@ import (
 type Check struct {
 	ID                 uuid.UUID `json:"id"`
 	LastTransitionTime time.Time `json:"last_transition_time"`
+	LastRuntime        time.Time `json:"last_runtime"`
+	CreatedAt          time.Time `json:"created_at"`
 	Status             string    `json:"status"`
 }
 
@@ -20,8 +22,6 @@ func (t Check) AsMap() map[string]any {
 	b, _ := json.Marshal(t)
 	_ = json.Unmarshal(b, &m)
 
-	transitionDuration := time.Since(t.LastTransitionTime)
-	m["transition_duration_sec"] = int(transitionDuration.Seconds())
-	m["transition_duration_min"] = int(transitionDuration.Minutes())
+	m["age"] = time.Since(t.LastTransitionTime)
 	return m
 }

--- a/api/check.go
+++ b/api/check.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Check struct {
+	ID                 uuid.UUID `json:"id"`
+	LastTransitionTime time.Time `json:"last_transition_time"`
+	Status             string    `json:"status"`
+}
+
+// AsMap returns a map[string]any representation of the Check object
+// with some additional fields.
+func (t Check) AsMap() map[string]any {
+	m := make(map[string]any)
+	b, _ := json.Marshal(t)
+	_ = json.Unmarshal(b, &m)
+
+	transitionDuration := time.Now().Sub(t.LastTransitionTime)
+	m["transition_duration_sec"] = int(transitionDuration.Seconds())
+	m["transition_duration_min"] = int(transitionDuration.Minutes())
+	return m
+}

--- a/api/check.go
+++ b/api/check.go
@@ -20,7 +20,7 @@ func (t Check) AsMap() map[string]any {
 	b, _ := json.Marshal(t)
 	_ = json.Unmarshal(b, &m)
 
-	transitionDuration := time.Now().Sub(t.LastTransitionTime)
+	transitionDuration := time.Since(t.LastTransitionTime)
 	m["transition_duration_sec"] = int(transitionDuration.Seconds())
 	m["transition_duration_min"] = int(transitionDuration.Minutes())
 	return m

--- a/db/evidences.go
+++ b/db/evidences.go
@@ -15,6 +15,7 @@ type Hypothesis struct {
 type EvidenceScriptInput struct {
 	api.Evidence
 	ConfigItem api.ConfigItem `json:"config,omitempty" gorm:"foreignKey:ConfigID;references:ID"`
+	Check      api.Check      `json:"check,omitempty" gorm:"foreignKey:CheckID;references:ID"`
 	Component  api.Component  `json:"component,omitempty"`
 	Hypothesis Hypothesis
 }
@@ -25,6 +26,7 @@ func GetEvidenceScripts() []EvidenceScriptInput {
 	hypothesesSubQuery := Gorm.Table("hypotheses").Select("id").Where("incident_id IN (?)", incidentsSubQuery)
 	err := Gorm.Table("evidences").
 		Joins("ConfigItem").
+		Joins("Check").
 		Joins("Component").
 		Joins("Hypothesis").
 		Preload("Hypothesis.Incident").
@@ -34,8 +36,9 @@ func GetEvidenceScripts() []EvidenceScriptInput {
 
 	if err != nil {
 		logger.Errorf("error fetching the evidences: %v", err)
-		return evidences
+		return nil
 	}
+
 	return evidences
 }
 

--- a/evidence_done_test.go
+++ b/evidence_done_test.go
@@ -235,7 +235,7 @@ var _ = ginkgo.Describe("Test Incident Done Definition With Health Check", ginkg
 			CreatedBy:        john.ID,
 			Description:      "Logisctics DB attached component",
 			Type:             "component",
-			Script:           `check.status == "healthy" && check.transition_duration_sec > 30`,
+			Script:           `check.status == "healthy" && check.age > duration("30s")`,
 			CheckID:          &check.ID,
 			DefinitionOfDone: true,
 		}

--- a/jobs/evidence_script_cel_test.go
+++ b/jobs/evidence_script_cel_test.go
@@ -1,0 +1,76 @@
+package jobs
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/db"
+)
+
+func Test_duration_func(t *testing.T) {
+	testData := []struct {
+		name               string
+		script             string
+		output             bool
+		createdAt          time.Time
+		lastTransitionTime time.Time
+	}{
+		{
+			name:               "age compare | duration in seconds | fail",
+			script:             `check.status == 'healthy' && check.age > duration("16s")`,
+			lastTransitionTime: time.Now().Add(-time.Second * 15),
+			output:             false,
+		},
+		{
+			name:               "age compare | duration in seconds | pass",
+			script:             `check.status == 'healthy' && check.age > duration("15s")`,
+			lastTransitionTime: time.Now().Add(-time.Second * 20),
+			output:             true,
+		},
+		{
+			name:               "age compare | duration in minutes | fail",
+			script:             `check.status == 'healthy' && check.age > duration("10m")`,
+			lastTransitionTime: time.Now().Add(-time.Minute * 5),
+			output:             false,
+		},
+		{
+			name:               "age compare | duration in minutes | pass",
+			script:             `check.status == 'healthy' && check.age > duration("10m")`,
+			lastTransitionTime: time.Now().Add(-time.Minute * 15),
+			output:             true,
+		},
+		// {
+		// 	name:               `duration days pass | not supported by cel (Supported: "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)). (https://github.com/google/cel-spec/blob/master/doc/langdef.md)`,
+		// 	script:             `check.status == 'healthy' && check.age > duration("10d")`,
+		// 	lastTransitionTime: time.Now().Add(-time.Hour * 24 * 15),
+		// 	output:             true,
+		// },
+	}
+
+	for _, td := range testData {
+		evidence := db.EvidenceScriptInput{
+			Evidence: api.Evidence{
+				Script:           td.script,
+				DefinitionOfDone: true,
+			},
+			Check: api.Check{
+				LastTransitionTime: td.lastTransitionTime,
+				Status:             "healthy",
+				CreatedAt:          td.createdAt,
+				LastRuntime:        time.Now().Add(-time.Hour),
+			},
+		}
+
+		out, err := evaluate(evidence)
+		if err != nil {
+			t.Fatalf("[%s] unexpected error: %v", td.name, err)
+		}
+
+		output, _ := strconv.ParseBool(out)
+		if output != td.output {
+			t.Fatalf("[%s] expected %v, got %v", td.name, td.output, out)
+		}
+	}
+}


### PR DESCRIPTION
* cel expression didn't not env var about the check. Now it's added.
* added test for incident done definition using checks.
* fixed bug in previous done definition using config test.

Resolves: https://github.com/flanksource/incident-commander/issues/281