### PR TITLE
feat: return a cursor timestamp to agent on canary request

### DIFF
--- a/api/upstream.go
+++ b/api/upstream.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"time"
+
+	"github.com/flanksource/duty/models"
 	"github.com/flanksource/duty/upstream"
 )
 
@@ -15,3 +18,8 @@ var TablesToReconcile = []string{
 }
 
 var UpstreamConf upstream.UpstreamConfig
+
+type CanaryPullResponse struct {
+	Before   time.Time       `json:"before"`
+	Canaries []models.Canary `json:"canaries,omitempty"`
+}


### PR DESCRIPTION
so the canary agent doesn't receive entire canaries on every pull request