### PR TITLE
feat: mapping identities to roles & teams

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,17 @@ func PreRun(cmd *cobra.Command, args []string) {
 		WithDB(db.Gorm, db.Pool).
 		WithKubernetes(api.Kubernetes).
 		WithNamespace(api.Namespace)
+
+	if strings.HasPrefix(auth.IdentityRoleMapper, "file://") {
+		path := strings.TrimPrefix(auth.IdentityRoleMapper, "file://")
+		content, err := os.ReadFile(path)
+		if err != nil {
+			logger.Fatalf("failed to read identity role mapper script file(%s): %v", path, err)
+		}
+
+		auth.IdentityRoleMapper = string(content)
+		logger.Debugf("successfully loaded identity-role-mapper from file: %s", auth.IdentityRoleMapper)
+	}
 }
 
 var Root = &cobra.Command{
@@ -87,7 +98,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&mail.FromName, "email-from-name", "Mission Control", "Email name of the sender")
 	flags.StringVar(&db.PostgresDBAnonRole, "postgrest-anon-role", "postgrest_anon", "PostgREST anonymous role")
 	flags.StringVar(&db.PostgrestMaxRows, "postgrest-max-rows", "2000", "A hard limit to the number of rows PostgREST will fetch")
-	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role & a team. Should return {role: string, teams: []string}")
+	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role & a team (return: {role: string, teams: []string}). Supports file path (prefixed with 'file://').")
 	flags.StringVar(&otelcollectorURL, "otel-collector-url", "", "OpenTelemetry gRPC Collector URL in host:port format")
 	flags.StringVar(&otelServiceName, "otel-service-name", "mission-control", "OpenTelemetry service name for the resource")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&mail.FromName, "email-from-name", "Mission Control", "Email name of the sender")
 	flags.StringVar(&db.PostgresDBAnonRole, "postgrest-anon-role", "postgrest_anon", "PostgREST anonymous role")
 	flags.StringVar(&db.PostgrestMaxRows, "postgrest-max-rows", "2000", "A hard limit to the number of rows PostgREST will fetch")
-	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role & a team. Should return {role: string, team: string}")
+	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role & a team. Should return {role: string, teams: []string}")
 	flags.StringVar(&otelcollectorURL, "otel-collector-url", "", "OpenTelemetry gRPC Collector URL in host:port format")
 	flags.StringVar(&otelServiceName, "otel-service-name", "mission-control", "OpenTelemetry service name for the resource")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,7 +87,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&mail.FromName, "email-from-name", "Mission Control", "Email name of the sender")
 	flags.StringVar(&db.PostgresDBAnonRole, "postgrest-anon-role", "postgrest_anon", "PostgREST anonymous role")
 	flags.StringVar(&db.PostgrestMaxRows, "postgrest-max-rows", "2000", "A hard limit to the number of rows PostgREST will fetch")
-	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role")
+	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role & a team. Should return {role: string, team: string}")
 	flags.StringVar(&otelcollectorURL, "otel-collector-url", "", "OpenTelemetry gRPC Collector URL in host:port format")
 	flags.StringVar(&otelServiceName, "otel-service-name", "mission-control", "OpenTelemetry service name for the resource")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flanksource/commons/utils"
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/incident-commander/api"
+	"github.com/flanksource/incident-commander/auth"
 	"github.com/flanksource/incident-commander/db"
 	"github.com/flanksource/incident-commander/jobs"
 	"github.com/flanksource/incident-commander/k8s"
@@ -86,6 +87,7 @@ func ServerFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&mail.FromName, "email-from-name", "Mission Control", "Email name of the sender")
 	flags.StringVar(&db.PostgresDBAnonRole, "postgrest-anon-role", "postgrest_anon", "PostgREST anonymous role")
 	flags.StringVar(&db.PostgrestMaxRows, "postgrest-max-rows", "2000", "A hard limit to the number of rows PostgREST will fetch")
+	flags.StringVar(&auth.IdentityRoleMapper, "identity-role-mapper", "", "CEL-Go expression to map identity to a role")
 	flags.StringVar(&otelcollectorURL, "otel-collector-url", "", "OpenTelemetry gRPC Collector URL in host:port format")
 	flags.StringVar(&otelServiceName, "otel-service-name", "mission-control", "OpenTelemetry service name for the resource")
 

--- a/db/models/team.go
+++ b/db/models/team.go
@@ -18,3 +18,8 @@ type Team struct {
 	UpdatedAt time.Time  `gorm:"type:timestamp with time zone;default:now();not null"`
 	DeletedAt *time.Time `gorm:"type:timestamp with time zone"`
 }
+
+type TeamMember struct {
+	TeamID   uuid.UUID `gorm:"not null"`
+	PersonID uuid.UUID `gorm:"not null"`
+}

--- a/db/people.go
+++ b/db/people.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flanksource/duty/context"
 	"github.com/flanksource/duty/models"
 	"github.com/flanksource/incident-commander/api"
+	dbModels "github.com/flanksource/incident-commander/db/models"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/argon2"
 	"gorm.io/gorm/clause"
@@ -104,4 +105,11 @@ func CreateAccessToken(ctx context.Context, personID uuid.UUID, name, password s
 
 	formattedHash := fmt.Sprintf("%s.%s.%d.%d.%d", password, salt, timeCost, memoryCost, parallelism)
 	return formattedHash, nil
+}
+
+func AddPersonToTeam(ctx context.Context, personID uuid.UUID, teamID uuid.UUID) error {
+	return ctx.DB().
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&dbModels.TeamMember{PersonID: personID, TeamID: teamID}).
+		Error
 }

--- a/rbac/middleware.go
+++ b/rbac/middleware.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/flanksource/commons/collections"
 	"github.com/flanksource/commons/logger"
-	"github.com/flanksource/duty/context"
 	"github.com/flanksource/incident-commander/api"
 	"github.com/labstack/echo/v4"
 )
@@ -60,11 +59,6 @@ func Authorization(object, action string) func(echo.HandlerFunc) echo.HandlerFun
 
 			if object == "" || action == "" {
 				return c.String(http.StatusForbidden, errMisconfiguredRBAC.Error())
-			}
-
-			ctx := c.Request().Context().(context.Context)
-			if role, ok := ctx.Value("identity.role").(string); ok && role != "" {
-				userID = role
 			}
 
 			if !Check(userID, object, action) {


### PR DESCRIPTION
- [x] The argument should also accept a path to read the script, which we mount into a config map from the chart
- [x] the evaluated role from the expression should be persisted 





